### PR TITLE
Cleaning up the tests

### DIFF
--- a/t/001_declare_exchange.t
+++ b/t/001_declare_exchange.t
@@ -1,4 +1,4 @@
-use Test::More tests => 8;
+use Test::More tests => 9;
 use strict;
 use warnings;
 
@@ -29,6 +29,9 @@ eval { $mq->exchange_declare(1, $exchange."internal0.auto_delete1", { exchange_t
 is($@, '', "exchange_declare");
 
 eval { $mq->exchange_declare(1, $exchange."internal1.auto_delete1", { exchange_type => "direct", passive => 0, durable => 1, auto_delete => 1, internal => 1 }); };
+is($@, '', "exchange_declare");
+
+eval { $mq->exchange_delete(1, $exchange, { exchange_type => "direct", passive => 0, durable => 1, auto_delete => 0, internal => 0 }); };
 is($@, '', "exchange_declare");
 
 1;

--- a/t/002_publish.t
+++ b/t/002_publish.t
@@ -1,4 +1,4 @@
-use Test::More tests => 8;
+use Test::More tests => 13;
 use strict;
 use warnings;
 
@@ -19,6 +19,12 @@ eval { $mq->connect($host, { user => "guest", password => "guest" }); };
 is($@, '', "connect");
 eval { $mq->channel_open(1); };
 is($@, '', "channel_open");
+
+# Re-establish the exchange if it wasn't created in 001
+eval { $mq->exchange_declare(1, $exchange, { exchange_type => "direct", passive => 0, durable => 1, auto_delete => 0, internal => 0 }); };
+is($@, '', "exchange_declare");
+
+# Declare the queue and bind
 eval { $mq->queue_declare(1, $queuename, { passive => 0, durable => 1, exclusive => 0, auto_delete => 0 }); };
 is($@, '', "queue_declare");
 eval { $mq->queue_bind(1, $queuename, $exchange, $routekey); };
@@ -43,5 +49,19 @@ eval { $mq->publish(1, $routekey, "Magic Payload",
                        },
                    ); };
 is($@, '', "publish");
+
+
+# Clean up
+eval { 1 while($mq->purge(1, $queuename)); };
+is($@, '', "purge queue");
+
+eval { $mq->queue_unbind(1, $queuename, $exchange, $routekey); };
+is($@, '', "queue_unbind");
+
+eval { $mq->queue_delete(1, $queuename); };
+is($@, '', "queue_delete");
+
+eval { $mq->exchange_delete(1, $exchange); };
+is($@, '', "exchange_delete");
 
 1;

--- a/t/003_consume.t
+++ b/t/003_consume.t
@@ -1,4 +1,4 @@
-use Test::More tests => 18;
+use Test::More tests => 27;
 use strict;
 use warnings;
 
@@ -22,6 +22,42 @@ eval { $mq->connect($host, { user => "guest", password => "guest" }); };
 is($@, '', "connect");
 eval { $mq->channel_open(1); };
 is($@, '', "channel_open");
+
+# Re-establish the exchange if it wasn't created in 001
+# or in 002
+eval { $mq->exchange_declare(1, $exchange, { exchange_type => "direct", passive => 0, durable => 1, auto_delete => 0, internal => 0 }); };
+is($@, '', "exchange_declare");
+
+# Re-establish the queue if it wasn't made in test 002
+eval { $mq->queue_declare(1, $queuename, { passive => 0, durable => 1, exclusive => 0, auto_delete => 0 }); };
+is($@, '', "queue_declare");
+eval { $mq->queue_bind(1, $queuename, $exchange, $routekey); };
+is($@, '', "queue_bind");
+
+# We want to drain the queue first...
+eval { 1 while($mq->purge(1, $queuename)); };
+is($@, '', "purge queue");
+
+# We want this test to be self-contained, so we need
+# to publish ourselves.
+eval { $mq->publish(1, $routekey, "Magic Payload", 
+                       { exchange => $exchange },
+                       {
+                        content_type => 'text/plain',
+                        content_encoding => 'none',
+                        correlation_id => '123',
+                        reply_to => 'somequeue',
+                        expiration => 60 * 1000,
+                        message_id => 'ABC',
+                        type => 'notmytype',
+                        user_id => 'guest',
+                        app_id => 'idd',
+                        delivery_mode => 1,
+                        priority => 2,
+                        timestamp => 1271857990,
+                       },
+                   ); };
+is($@, '', "publish");
 
 my $consumer_tag = 'ctag';
 my $tag_back;
@@ -77,5 +113,21 @@ ok(abs(tv_interval($start)) < 0.01, "Timeout about immediate");
 is($@, '', 'immediate recv');
 is($rv, undef, 'immediate recv returns undef');
 
+
+# Clean up
 eval { $mq->cancel(1, $consumer_tag); };
 is($@, '', 'cancel');
+
+eval { 1 while($mq->purge(1, $queuename)); };
+is($@, '', "purge queue");
+
+eval { $mq->queue_unbind(1, $queuename, $exchange, $routekey); };
+is($@, '', "queue_unbind");
+
+eval { $mq->queue_delete(1, $queuename); };
+is($@, '', "queue_delete");
+
+eval { $mq->exchange_delete(1, $exchange); };
+is($@, '', "exchange_delete");
+
+1;

--- a/t/004_selfconsume.t
+++ b/t/004_selfconsume.t
@@ -1,4 +1,4 @@
-use Test::More tests => 11;
+use Test::More tests => 15;
 use strict;
 use warnings;
 
@@ -19,14 +19,28 @@ eval { $mq->connect($host, { user => "guest", password => "guest" }); };
 is($@, '', "connect");
 eval { $mq->channel_open(1); };
 is($@, '', "channel_open");
+
+# Re-establish the exchange if it wasn't created in 001
+# or in 002
+eval { $mq->exchange_declare(1, $exchange, { exchange_type => "direct", passive => 0, durable => 1, auto_delete => 0, internal => 0 }); };
+is($@, '', "exchange_declare");
+
 my $queuename = '';
 eval { $queuename = $mq->queue_declare(1, '', { passive => 0, durable => 1, exclusive => 0, auto_delete => 1 }); };
 is($@, '', "queue_declare");
 isnt($queuename, '', "queue_declare -> private name");
 eval { $mq->queue_bind(1, $queuename, $exchange, $routekey); };
 is($@, '', "queue_bind");
+
+# We want to drain the queue first...
+eval { 1 while($mq->purge(1, $queuename)); };
+is($@, '', "purge queue");
+
+# Publish
 eval { $mq->publish(1, $routekey, "Magic Transient Payload", { exchange => $exchange }); };
 is($@, '', "publish");
+
+# Set up the consumer
 eval { $mq->consume(1, $queuename, {consumer_tag=>'ctag', no_local=>0,no_ack=>1,exclusive=>0}); };
 is($@, '', "consume");
 
@@ -43,5 +57,12 @@ is_deeply($rv,
           'consumer_tag' => 'ctag',
           'props' => {},
           }, "payload");
+
+# Clean up
+eval { $mq->cancel(1, 'ctag'); };
+is($@, '', 'cancel');
+
+eval { $mq->exchange_delete(1, $exchange); };
+is($@, '', "exchange_delete");
 
 1;

--- a/t/005_noack.t
+++ b/t/005_noack.t
@@ -1,4 +1,4 @@
-use Test::More tests => 16;
+use Test::More tests => 22;
 use strict;
 use warnings;
 
@@ -22,12 +22,21 @@ eval { $mq->connect($host, { user => "guest", password => "guest" }); };
 is($@, '', "connect");
 eval { $mq->channel_open(1); };
 is($@, '', "channel_open");
+
+# Re-establish the exchange if it wasn't created in 001
+# or in 002
+eval { $mq->exchange_declare(1, $exchange, { exchange_type => "direct", passive => 0, durable => 1, auto_delete => 0, internal => 0 }); };
+is($@, '', "exchange_declare");
+
 eval { $mq->queue_declare(1, $queuename, { passive => 0, durable => 1, exclusive => 0, auto_delete => 0 }); };
 is($@, '', "queue_declare");
+
 eval { $mq->queue_bind(1, $queuename, $exchange, $routekey); };
 is($@, '', "queue_bind");
+
 eval { $mq->purge(1, $queuename); };
 is($@, '', "purge");
+
 eval { $mq->publish(1, $routekey, "Magic Payload $$", { exchange => $exchange }); };
 is($@, '', "publish");
 eval { $mq->consume(1, $queuename, { no_ack => 0, consumer_tag=>'ctag' } ); };
@@ -70,3 +79,21 @@ is_deeply($payload,
           }, "payload");
 eval { $mq->ack(1, $ack_tag); };
 is($@, '', "acking");
+
+# Clean up
+eval { $mq->cancel(1, 'ctag'); };
+is($@, '', 'cancel');
+
+eval { 1 while($mq->purge(1, $queuename)); };
+is($@, '', "purge queue");
+
+eval { $mq->queue_unbind(1, $queuename, $exchange, $routekey); };
+is($@, '', "queue_unbind");
+
+eval { $mq->queue_delete(1, $queuename); };
+is($@, '', "queue_delete");
+
+eval { $mq->exchange_delete(1, $exchange); };
+is($@, '', "exchange_delete");
+
+1;

--- a/t/006_txn.t
+++ b/t/006_txn.t
@@ -1,4 +1,4 @@
-use Test::More tests => 13;
+use Test::More tests => 16;
 use strict;
 use warnings;
 
@@ -21,6 +21,12 @@ eval { $mq->connect($host, { user => "guest", password => "guest" }); };
 is($@, '', "connect");
 eval { $mq->channel_open(1); };
 is($@, '', "channel_open");
+
+# Re-establish the exchange if it wasn't created in 001
+# or in 002
+eval { $mq->exchange_declare(1, $exchange, { exchange_type => "direct", passive => 0, durable => 1, auto_delete => 0, internal => 0 }); };
+is($@, '', "exchange_declare");
+
 my $queuename = '';
 eval { $queuename = $mq->queue_declare(1, '', { passive => 0, durable => 1, exclusive => 0, auto_delete => 1 }); };
 is($@, '', "queue_declare");
@@ -52,5 +58,12 @@ is_deeply($rv,
           'consumer_tag' => 'ctag',
           'props' => {},
           }, "payload");
+
+# Clean up
+eval { $mq->cancel(1, 'ctag'); };
+is($@, '', 'cancel');
+
+eval { $mq->exchange_delete(1, $exchange); };
+is($@, '', "exchange_delete");
 
 1;

--- a/t/007_get.t
+++ b/t/007_get.t
@@ -1,4 +1,4 @@
-use Test::More tests => 17;
+use Test::More tests => 22;
 use strict;
 use warnings;
 
@@ -20,6 +20,12 @@ eval { $mq->connect($host, { user => "guest", password => "guest" }); };
 is($@, '', "connect");
 eval { $mq->channel_open(1); };
 is($@, '', "channel_open");
+
+# Re-establish the exchange if it wasn't created in 001
+# or in 002
+eval { $mq->exchange_declare(1, $exchange, { exchange_type => "direct", passive => 0, durable => 1, auto_delete => 0, internal => 0 }); };
+is($@, '', "exchange_declare");
+
 my $queuename = '';
 eval { $queuename = $mq->queue_declare(1, '', { passive => 0, durable => 0, exclusive => 0, auto_delete => 1 }); };
 is($@, '', "queue_declare");
@@ -114,3 +120,18 @@ is_deeply($getr,
             },
             body => 'Magic Transient Payload 2',
           }, "get should see message");
+
+# Clean up
+eval { 1 while($mq->purge(1, $queuename)); };
+is($@, '', "purge queue");
+
+eval { $mq->queue_unbind(1, $queuename, $exchange, $routekey); };
+is($@, '', "queue_unbind");
+
+eval { $mq->queue_delete(1, $queuename); };
+is($@, '', "queue_delete");
+
+eval { $mq->exchange_delete(1, $exchange); };
+is($@, '', "exchange_delete");
+
+1;

--- a/t/013_headers.t
+++ b/t/013_headers.t
@@ -1,4 +1,4 @@
-use Test::More tests => 20;
+use Test::More tests => 26;
 use strict;
 use warnings;
 
@@ -33,6 +33,11 @@ is($@, '', "connect");
 
 eval { $mq->channel_open(1); };
 is($@, '', "channel_open");
+
+# Re-establish the exchange if it wasn't created in 001
+# or in 002
+eval { $mq->exchange_declare(1, $exchange, { exchange_type => "direct", passive => 0, durable => 1, auto_delete => 0, internal => 0 }); };
+is($@, '', "exchange_declare");
 
 eval { $mq->queue_declare(1, $queuename, { passive => 0, durable => 1, exclusive => 0, auto_delete => 0 }); };
 is($@, '', "queue_declare");
@@ -124,3 +129,21 @@ PERL
 
 	is_deeply( $msg->{props}{headers}, $headers, "Received magic headers" );
 };
+
+# Clean up
+eval { $mq->cancel(1, 'ctag'); };
+is($@, '', 'cancel');
+
+eval { 1 while($mq->purge(1, $queuename)); };
+is($@, '', "purge queue");
+
+eval { $mq->queue_unbind(1, $queuename, $exchange, $routekey); };
+is($@, '', "queue_unbind");
+
+eval { $mq->queue_delete(1, $queuename); };
+is($@, '', "queue_delete");
+
+eval { $mq->exchange_delete(1, $exchange); };
+is($@, '', "exchange_delete");
+
+1;

--- a/t/015_declare_queue_with_headers.t
+++ b/t/015_declare_queue_with_headers.t
@@ -1,4 +1,4 @@
-use Test::More 'no_plan'; #  20;
+use Test::More tests => 6;
 use strict;
 use warnings;
 

--- a/t/019_utf8_safety.t
+++ b/t/019_utf8_safety.t
@@ -1,4 +1,4 @@
-use Test::More tests => 29;
+use Test::More tests => 32;
 use strict;
 use warnings;
 use utf8;
@@ -24,6 +24,12 @@ eval { $mq->connect($host, { user => "guest", password => "guest" }); };
 is($@, '', "connect");
 eval { $mq->channel_open(1); };
 is($@, '', "channel_open");
+
+# Re-establish the exchange if it wasn't created in 001
+# or in 002
+eval { $mq->exchange_declare(1, $exchange, { exchange_type => "direct", passive => 0, durable => 1, auto_delete => 0, internal => 0 }); };
+is($@, '', "exchange_declare");
+
 my $queuename = '';
 eval { $queuename = $mq->queue_declare(1, '', { passive => 0, durable => 1, exclusive => 0, auto_delete => 1 }); };
 is($@, '', "queue_declare");
@@ -141,5 +147,12 @@ is_deeply($rv,
           }, "payload");
 ok( ! utf8::is_utf8($rv->{'body'}), 'not utf8');
 ok( utf8::is_utf8($rv->{'props'}->{"headers"}->{"sample"}), 'is utf8');
+
+# Clean up
+eval { $mq->cancel(1, 'ctag'); };
+is($@, '', 'cancel');
+
+eval { $mq->exchange_delete(1, $exchange); };
+is($@, '', "exchange_delete");
 
 1;

--- a/t/021_json_utf8_in_and_out.t
+++ b/t/021_json_utf8_in_and_out.t
@@ -8,7 +8,7 @@ eval ("use JSON;");
 if ( $@ ) {
      plan skip_all => "Missing JSON.pm";
 } else {
-     plan tests => 21;
+     plan tests => 24;
 }
 use Sys::Hostname;
 my $unique = hostname . "-$^O-$^V"; #hostname-os-perlversion
@@ -28,6 +28,12 @@ eval { $mq->connect($host, { user => "guest", password => "guest" }); };
 is($@, '', "connect");
 eval { $mq->channel_open(1); };
 is($@, '', "channel_open");
+
+# Re-establish the exchange if it wasn't created in 001
+# or in 002
+eval { $mq->exchange_declare(1, $exchange, { exchange_type => "direct", passive => 0, durable => 1, auto_delete => 0, internal => 0 }); };
+is($@, '', "exchange_declare");
+
 my $queuename = '';
 eval { $queuename = $mq->queue_declare(1, '', { passive => 0, durable => 1, exclusive => 0, auto_delete => 1 }); };
 is($@, '', "queue_declare");
@@ -88,5 +94,12 @@ is_deeply($rv,
           'props' => { 'content_encoding' => 'C' },
           }, "payload");
 ok( ! utf8::is_utf8($rv->{'body'}), 'not utf8');
+
+# Clean up
+eval { $mq->cancel(1, 'ctag'); };
+is($@, '', 'cancel');
+
+eval { $mq->exchange_delete(1, $exchange); };
+is($@, '', "exchange_delete");
 
 1;


### PR DESCRIPTION
We keep having cascades of test failures if tests 1-3 fail. It looks
like a whole bunch of stuff fails, which is essentially just a bunch of
false-positives.

While it is likely that one of those testing indicates a full failure
(usually one of connectivity), it doesn’t necessarily mean it. This
will allow us to pass more tests if there are minor connectivity
hiccups, and maybe better lead us to the real cause of actual library
bugs.