### PR TITLE
Added server and client properties

### DIFF
--- a/RabbitMQ.pm
+++ b/RabbitMQ.pm
@@ -79,6 +79,14 @@ C<$options> is an optional hash respecting the following keys:
 
 Causes the connection to RabbitMQ to be torn down.
 
+=head2 get_server_properties()
+
+Get a hashref of server properties (these may vary, you should C<Data::Dumper> to inspect). They will be provided by the RabbitMQ server to which you are connected.
+
+=head2 get_client_properties()
+
+Get a hashref of server properties (these may vary, you should C<Data::Dumper> to inspect).
+
 =head2 is_connected()
 
 Returns true if a valid socket connection appears to exist, false otherwise.

--- a/RabbitMQ.xs
+++ b/RabbitMQ.xs
@@ -633,6 +633,11 @@ SV* mq_array_to_arrayref(amqp_array_t *mq_array) {
     __DEBUG__( warn("%d KIND >%c<", __LINE__, mq_element->kind) );
 
     switch (mq_element->kind) {
+      // Boolean
+      case AMQP_FIELD_KIND_BOOLEAN:
+        perl_element = newSViv(mq_element->value.boolean);
+        break;
+
       // Signed values
       case AMQP_FIELD_KIND_I8:
         perl_element = newSViv(mq_element->value.i8);
@@ -734,6 +739,11 @@ SV* mq_table_to_hashref( amqp_table_t *mq_table ) {
     );
 
     switch (hash_entry->value.kind) {
+      // Boolean
+      case AMQP_FIELD_KIND_BOOLEAN:
+        perl_element = newSViv(hash_entry->value.value.boolean);
+        break;
+
       // Integers
       case AMQP_FIELD_KIND_I8:
         perl_element = newSViv(hash_entry->value.value.i8);
@@ -1651,3 +1661,39 @@ net_amqp_rabbitmq_basic_qos(conn, channel, args = NULL)
     amqp_basic_qos(conn, channel,
                    prefetch_size, prefetch_count, global);
     die_on_amqp_error(aTHX_ amqp_get_rpc_reply(conn), conn, "Basic QoS");
+
+SV* net_amqp_rabbitmq_get_server_properties(conn)
+  Net::AMQP::RabbitMQ conn
+  PREINIT:
+    amqp_table_t* server_properties;
+  CODE:
+    assert_amqp_connected(conn);
+    server_properties = amqp_get_server_properties(conn);
+    if ( server_properties )
+    {
+      RETVAL = mq_table_to_hashref(server_properties);
+    }
+    else
+    {
+      RETVAL = (SV*)&PL_sv_undef;
+    }
+  OUTPUT:
+    RETVAL
+
+SV* net_amqp_rabbitmq_get_client_properties(conn)
+  Net::AMQP::RabbitMQ conn
+  PREINIT:
+    amqp_table_t* client_properties;
+  CODE:
+    assert_amqp_connected(conn);
+    client_properties = amqp_get_client_properties(conn);
+    if ( client_properties )
+    {
+      RETVAL = mq_table_to_hashref(client_properties);
+    }
+    else
+    {
+      RETVAL = (SV*)&PL_sv_undef;
+    }
+  OUTPUT:
+    RETVAL

--- a/t/024_boolean_header_fields.t
+++ b/t/024_boolean_header_fields.t
@@ -50,7 +50,7 @@ my $ua = LWP::UserAgent->new;
 for my $test_def (['true', 1], ['false', 0]) {
     my($boolean_value, $perl_value) = @$test_def;
     my $resp = $ua->post("http://guest:guest\@$host/mgmt/api/exchanges/%2F/$exchange/publish", Content => <<"EOF");
-{"properties":{"headers":{"booltest":$boolean_value}},"routing_key":"$routekey","payload":"test boolean","payload_encoding":"string"}
+{"properties":{"headers":{"booltest":$boolean_value,"boollist":[true,false]}},"routing_key":"$routekey","payload":"test boolean","payload_encoding":"string"}
 EOF
     ok $resp->is_success, "Publishing message with boolean value $boolean_value"
 	or diag "Publishing booltest message failed: " . $resp->as_string;
@@ -67,7 +67,12 @@ EOF
 	       'redelivered' => 0,
 	       'exchange' => $exchange,
 	       'consumer_tag' => 'ctag',
-	       'props' => { 'headers' => { 'booltest' => $perl_value } },
+	       'props' => {
+                'headers' => {
+                    'booltest' => $perl_value,
+                    'boollist' => [1,0]
+                }
+            },
 	      }, "payload and header with boolean value $boolean_value");
 }
 

--- a/t/029_amqp_properties.t
+++ b/t/029_amqp_properties.t
@@ -1,0 +1,41 @@
+use Test::More tests => 11;
+use strict;
+use warnings;
+
+my $host = $ENV{'MQHOST'} || "dev.rabbitmq.com";
+
+use_ok('Net::AMQP::RabbitMQ');
+
+my $mq = Net::AMQP::RabbitMQ->new();
+ok($mq, "Created object");
+
+
+# Verify we enforce server_properties connection requirement
+eval { my $results = $mq->get_server_properties(); };
+like( $@, qr/AMQP socket not connected/, "no socket, no get_server_properties" );
+
+# Verify we enforce client_properties connection requirement
+eval { my $results = $mq->get_client_properties(); };
+like( $@, qr/AMQP socket not connected/, "no socket, no get_client_properties" );
+
+# Now connect
+eval { $mq->connect($host, { user => "guest", password => "guest" }); };
+is($@, '', "connect");
+
+# Now verify server properties
+my $server_properties = undef;
+eval { $server_properties = $mq->get_server_properties(); };
+is($@, '', "get_server_properties");
+
+ok(exists( $server_properties->{product} ), 'product should be returned');
+is($server_properties->{'product'}, 'RabbitMQ', 'product is RabbitMQ');
+
+# Now verify client properties
+my $client_properties = undef;
+eval { $client_properties = $mq->get_client_properties(); };
+is($@, '', "get_server_properties");
+ok(exists( $client_properties->{product} ), 'product should be returned');
+is($client_properties->{'product'}, 'rabbitmq-c', 'product is rabbitmq-c');
+
+1;
+


### PR DESCRIPTION
- Added `get_client_properties()` to fetch client properties from a
connected instance.
- Added `get_server_properties()` to fetch server properties from a
connected instance.
- Added these two methods to tests.
- Added these two methods to documentation
- Added a handle for `AMQP_FIELD_KIND_BOOLEAN` in the mq conversion
code for arrays and tables.
- Updated tests for boolean headers to play nice with the boolean type
headers.