### PR TITLE
Handle fork

### DIFF
--- a/RabbitMQ.pm
+++ b/RabbitMQ.pm
@@ -473,6 +473,18 @@ Send a heartbeat frame.  If you've connected with a heartbeat parameter,
 you must send a heartbeat periodically matching connection parameter or
 the server may snip the connection.
 
+=head2 do_not_disconnect_on_destroy()
+
+This should not be used except if use fork an open connection. This will avoid the child process to close the connection of the parent.
+
+ my $rmq = Net::AMQP::RabbitMQ->new;
+ if (!fork) {
+   $rmq->do_not_disconnect_on_destroy;
+   $rmq = Net::AMQ::RabbitMQ->new;
+   # do stuff
+   exit(0);
+ }
+
 =head1 WARNING AND ERROR MESSAGES
 
 =head2 Fatal Errors

--- a/t/031_fork_read_parent_and_child.t
+++ b/t/031_fork_read_parent_and_child.t
@@ -1,0 +1,94 @@
+use Test::More;
+use strict;
+use warnings;
+
+use FindBin qw/$Bin/;
+use lib "$Bin/lib";
+use NAR::Helper;
+
+my $helper = NAR::Helper->new;
+
+ok $helper->connect, "connected";
+ok $helper->channel_open, "channel_open";
+
+ok $helper->exchange_declare, "default exchange declare";
+
+my $queuename = $helper->queue_declare( undef, undef, 1 );
+ok $queuename, "queue declare";
+
+ok $helper->queue_bind( $queuename ), "queue bind";
+ok $helper->drain( $queuename ), "drain queue";
+
+{
+    my $getr = $helper->get( $queuename );
+    is( $getr, undef, "get returned undef" );
+}
+
+{
+    ok $helper->publish( "Magic Transient Payload" ), "publish";
+    ok $helper->publish( "Child should read this" ), "publish";
+    ok $helper->publish( "Read later" ), "publish";
+    my $getr = $helper->get( $queuename, 0 );
+    is_deeply(
+        $getr,
+        {
+            redelivered   => 0,
+            routing_key   => $helper->{routekey},
+            exchange      => $helper->{exchange},
+            message_count => 2,
+            delivery_tag  => 1,
+            props         => {},
+            body          => 'Magic Transient Payload',
+        },
+        "get should see message"
+    );
+    ok $helper->is_connected, 'is connected ok';
+}
+
+my $pid = fork();
+if (!$pid) {
+    $helper->mq->do_not_disconnect_on_destroy;
+    ok $helper->connect, "connected";
+    ok $helper->channel_open, "channel_open";
+    my $getr = $helper->get( $queuename, 0 );
+    is_deeply(
+        $getr,
+        {
+            redelivered   => 0,
+            routing_key   => $helper->{routekey},
+            exchange      => $helper->{exchange},
+            message_count => 1,
+            delivery_tag  => 1,
+            props         => {},
+            body          => 'Child should read this',
+        },
+        "get should see message"
+    );
+    ok $helper->is_connected, 'is connected ok';
+    $helper->ack($getr->{delivery_tag}, 1);
+    exit(0);
+} else {
+    waitpid($pid, 0);
+    ok $helper->is_connected, 'is connected ok';
+}
+{
+    my $getr = $helper->get( $queuename, 0 );
+    is_deeply(
+        $getr,
+        {
+            redelivered   => 0,
+            routing_key   => $helper->{routekey},
+            exchange      => $helper->{exchange},
+            message_count => 0,
+            delivery_tag  => 2,
+            props         => {},
+            body          => 'Read later',
+        },
+        "get should see message"
+    );
+    ok $helper->is_connected, 'is connected ok';
+    $helper->ack($getr->{delivery_tag}, 1);
+}
+
+ok $helper->cleanup( $queuename ), "cleanup";
+done_testing;

--- a/t/031_fork_read_parent_only.t
+++ b/t/031_fork_read_parent_only.t
@@ -1,0 +1,75 @@
+use Test::More;
+use strict;
+use warnings;
+
+use FindBin qw/$Bin/;
+use lib "$Bin/lib";
+use NAR::Helper;
+
+my $helper = NAR::Helper->new;
+
+ok $helper->connect, "connected";
+ok $helper->channel_open, "channel_open";
+
+ok $helper->exchange_declare, "default exchange declare";
+
+my $queuename = $helper->queue_declare( undef, undef, 1 );
+ok $queuename, "queue declare";
+
+ok $helper->queue_bind( $queuename ), "queue bind";
+ok $helper->drain( $queuename ), "drain queue";
+
+{
+    my $getr = $helper->get( $queuename );
+    is( $getr, undef, "get returned undef" );
+}
+
+{
+    ok $helper->publish( "Magic Transient Payload" ), "publish";
+    ok $helper->publish( "Read later" ), "publish";
+    my $getr = $helper->get( $queuename, 0 );
+    is_deeply(
+        $getr,
+        {
+            redelivered   => 0,
+            routing_key   => $helper->{routekey},
+            exchange      => $helper->{exchange},
+            message_count => 1,
+            delivery_tag  => 1,
+            props         => {},
+            body          => 'Magic Transient Payload',
+        },
+        "get should see message"
+    );
+    ok $helper->is_connected, 'is connected ok';
+}
+
+my $pid = fork();
+if (!$pid) {
+    $helper->mq->do_not_disconnect_on_destroy;
+    exit(0);
+} else {
+    waitpid($pid, 0);
+    ok $helper->is_connected, 'is connected ok';
+}
+{
+    my $getr = $helper->get( $queuename, 0 );
+    is_deeply(
+        $getr,
+        {
+            redelivered   => 0,
+            routing_key   => $helper->{routekey},
+            exchange      => $helper->{exchange},
+            message_count => 0,
+            delivery_tag  => 2,
+            props         => {},
+            body          => 'Read later',
+        },
+        "get should see message"
+    );
+    ok $helper->is_connected, 'is connected ok';
+    $helper->ack($getr->{delivery_tag}, 1);
+}
+
+ok $helper->cleanup( $queuename ), "cleanup";
+done_testing;


### PR DESCRIPTION
When we connect in a main method, do operation on the queue, then fork, even if the child do thing with the queue, when the fork exit, the parent loose his socket.

I have add a check of the pid in the "has_valid_connection", in order to avoid closing the socket in the child on destroy.

I also ensure that the child have a state of "not connected" when it try to access the socket. It is mandatory to reconnect in the child to use the module again.
