### PR TITLE
RabbitMQ: handle magic scalar SVt_PVMG

### DIFF
--- a/RabbitMQ.xs
+++ b/RabbitMQ.xs
@@ -188,19 +188,19 @@ amqp_field_value_kind_t amqp_kind_for_sv(SV** perl_value, short force_utf8) {
       return AMQP_FIELD_KIND_BYTES;
 
     case SVt_PVMG:
-      if ( SvPOKp( *perl_value ) ) {
+      if ( SvPOK( *perl_value ) || SvPOKp( *perl_value ) ) {
         if ( force_utf8 || SvUTF8( *perl_value ) ) {
             return AMQP_FIELD_KIND_UTF8;
         }
         return AMQP_FIELD_KIND_BYTES;
       }
-      if ( SvIOK( *perl_value ) ) {
+      if ( SvIOK( *perl_value ) || SvIOKp( *perl_value ) ) {
         if ( SvUOK( *perl_value ) ) {
           return AMQP_FIELD_KIND_U64;
         }
         return AMQP_FIELD_KIND_I64;
       }
-      if ( SvNOKp( *perl_value ) )  {
+      if ( SvNOK( *perl_value ) || SvNOKp( *perl_value ) )  {
         return AMQP_FIELD_KIND_F64;
       }
 

--- a/RabbitMQ.xs
+++ b/RabbitMQ.xs
@@ -187,6 +187,23 @@ amqp_field_value_kind_t amqp_kind_for_sv(SV** perl_value, short force_utf8) {
       }
       return AMQP_FIELD_KIND_BYTES;
 
+    case SVt_PVMG:
+      if ( SvPOKp( *perl_value ) ) {
+        if ( force_utf8 || SvUTF8( *perl_value ) ) {
+            return AMQP_FIELD_KIND_UTF8;
+        }
+        return AMQP_FIELD_KIND_BYTES;
+      }
+      if ( SvIOK( *perl_value ) ) {
+        if ( SvUOK( *perl_value ) ) {
+          return AMQP_FIELD_KIND_U64;
+        }
+        return AMQP_FIELD_KIND_I64;
+      }
+      if ( SvNOKp( *perl_value ) )  {
+        return AMQP_FIELD_KIND_F64;
+      }
+
     default:
       if ( SvROK( *perl_value ) ) {
         // Array Reference

--- a/t/031_magic_header_fields.t
+++ b/t/031_magic_header_fields.t
@@ -1,0 +1,68 @@
+use Test::More tests => 11;
+use strict;
+use warnings;
+
+use FindBin qw/$Bin/;
+use lib "$Bin/lib";
+use NAR::Helper;
+use Math::UInt64 qw/int64 uint64/;
+
+my $helper = NAR::Helper->new;
+
+ok $helper->connect, "connected";
+ok $helper->channel_open, "channel_open";
+ok $helper->exchange_declare, "default exchange declare";
+ok $helper->queue_declare, "queue declare";
+ok $helper->queue_bind, "queue bind";
+ok $helper->drain, "drain queue";
+
+# create scalars of type PVMG
+my ($magic_int, $magic_float, $magic_string);
+{
+    local $/ = 3;
+    $magic_int = $/;
+
+    my $x = $1;
+
+    local $/ = 1.2;
+    $magic_float = $/;
+
+    my $str = "abc12";
+    $str =~ /(\d+)/;
+    $magic_string = $1;
+}
+
+my $payload = "Message payload";
+my $headers = {
+    int    => $magic_int,
+    float  => $magic_float,
+    string => $magic_string,
+};
+
+ok $helper->publish( $payload, { headers => $headers } ), "publish";
+ok $helper->consume, "consume";
+
+my $rv = $helper->recv;
+ok $rv, "recv";
+
+is_deeply(
+    $rv,
+    {
+        body         => $payload,
+        routing_key  => $helper->{routekey},
+        delivery_tag => 1,
+        redelivered  => 0,
+        exchange     => $helper->{exchange},
+        consumer_tag => 'ctag',
+        props        => { 'headers' => {
+            int => 3,
+            float => 1.2,
+            string => "12",
+        } },
+    },
+    "payload"
+);
+
+END {
+    ok $helper->cleanup, "cleanup";
+}


### PR DESCRIPTION
Hi!
This is the last thing, that differs from the Net::AMQP::RabbitMQ we use at work and the git version, so I though I'd share it in case you are interested :)

This PR attempts to handle the magic scalar Perl values (SVt_PVMG). It recognizes some basic AMQP_FIELD_KIND_* types. (UTF8, BYTES, U64, I64, F64).