### PR TITLE
Fix the spelling in the documentation of the key for extra headers to include in a published message

### DIFF
--- a/RabbitMQ.pm
+++ b/RabbitMQ.pm
@@ -278,7 +278,7 @@ C<$props> is an optional hash (the AMQP 'props') respecting the following keys:
        delivery_mode => $integer,
        priority => $integer,
        timestamp => $integer,
-       header => $headers # This should be a hashref of keys and values.
+       headers => $headers # This should be a hashref of keys and values.
      }
 
 =head2 consume($channel, $queuename, $options)


### PR DESCRIPTION
Fixes https://github.com/net-amqp-rabbitmq/net-amqp-rabbitmq/issues/96