### PR TITLE
MQSKIPSSL skips t/030_ssl.t.

### DIFF
--- a/RabbitMQ.pm
+++ b/RabbitMQ.pm
@@ -483,6 +483,60 @@ the connection has been closed by the remote host, or otherwise invalidated,
 the socket will also be closed and should be re-opened before any additional
 calls are made.
 
+=head1 RUNNING THE TEST SUITE
+
+The test suite runs live tests against a RabbitMQ server at
+C<rabbitmq.thisaintnews.com>.  If you are in an environment that won't
+let you connect to this host (or the test server is down), you can use
+these environment variables:
+
+=over 4
+
+=item MQHOST
+
+Hostname or IP address of the RabbitMQ server to connect to (defaults
+to C<rabbitmq.thisaintnews.com>).
+
+=item MQUSERNAME
+
+Username for authentication (defaults to "nartest").
+
+=item MQPASSWORD
+
+Password for authentication (defaults to "reallysecure").
+
+=item MQSSL
+
+Whether the tests should run with SSL enabled (defaults to false, but
+see also C<MQSKIPSSL>).
+
+=item MQSSLCACERT
+
+Path to the certificate file for SSL-enabled connections, defaults to
+F<t/ssl/cacert.pem>.
+
+=item MQSSLVERIFYHOST
+
+Whether SSL hostname verification should be enabled (defaults to
+true).
+
+=item MQSSLINIT
+
+Whether the openssl library should be initialized (defaults to true).
+
+=item MQPORT
+
+Port of the RabbitMQ server to connect to (defaults to 5672, or 5673
+if SSL is enabled).
+
+=item MQSKIPSSL
+
+Whether the SSL tests should be skipped entirely.  This option exists
+because the SSL tests used to ignore C<MQSSL>, and to maintain
+backwards compatibility, still do.
+
+=back
+
 =head1 AUTHORS
 
 Theo Schlossnagle E<lt>jesus@omniti.comE<gt>

--- a/t/030_ssl.t
+++ b/t/030_ssl.t
@@ -18,13 +18,10 @@ if ($ENV{MQSKIPSSL}) {
 # already set by the user.  Those ought to work with the default
 # server at rabbitmq.thisaintnews.com (which you get if you don't set
 # MQHOST).
-local $ENV{MQSSL} = 1;
-local $ENV{MQSSLCACERT} = "$Bin/ssl/cacert.pem"
-    unless exists $ENV{MQSSLCACERT};
-local $ENV{MQSSLINIT} = 1
-    unless exists $ENV{MQSSLINIT};
-
-my $helper = NAR::Helper->new;
+my $helper = NAR::Helper->new(
+    ssl => 1,
+    ssl_cacert => exists $ENV{MQSSLCACERT} ? $ENV{MQSSLCACERT} : "$Bin/ssl/cacert.pem",
+    ssl_init => exists $ENV{MQSSLINIT} ? $ENV{MQSSLINIT} : 1);
 
 ok $helper->connect, "connected";
 ok $helper->channel_open, "channel_open";

--- a/t/030_ssl.t
+++ b/t/030_ssl.t
@@ -1,4 +1,4 @@
-use Test::More tests => 10;
+use Test::More;
 use strict;
 use warnings;
 
@@ -8,15 +8,23 @@ use NAR::Helper;
 
 use Time::HiRes qw(gettimeofday tv_interval);
 
-my $helper = NAR::Helper->new(
-    ssl        => 1,
-    port       => 5673,
-    host       => 'rabbitmq.thisaintnews.com',
-    ssl_cacert => "$Bin/ssl/cacert.pem",
-    ssl_init   => 1,
-    username   => 'nartest',
-    password   => 'reallysecure',
-);
+if ($ENV{MQSKIPSSL}) {
+    plan skip_all => 'SSL tests disabled by user';
+} else {
+    plan tests => 10;
+}
+
+# MQSKIPSSL not set, set SSL-related options to default values unless
+# already set by the user.  Those ought to work with the default
+# server at rabbitmq.thisaintnews.com (which you get if you don't set
+# MQHOST).
+local $ENV{MQSSL} = 1;
+local $ENV{MQSSLCACERT} = "$Bin/ssl/cacert.pem"
+    unless exists $ENV{MQSSLCACERT};
+local $ENV{MQSSLINIT} = 1
+    unless exists $ENV{MQSSLINIT};
+
+my $helper = NAR::Helper->new;
 
 ok $helper->connect, "connected";
 ok $helper->channel_open, "channel_open";
@@ -46,5 +54,7 @@ is_deeply(
 );
 
 END {
-    ok $helper->cleanup, "cleanup";
+    if (defined $helper) {
+        ok $helper->cleanup, "cleanup";
+    }
 }

--- a/t/lib/NAR/Helper.pm
+++ b/t/lib/NAR/Helper.pm
@@ -34,7 +34,7 @@ sub new {
     }
 
     my $port;
-    if ( $ssl ) {
+    if ( $ssl || $options{ssl} ) {
         Test::More::note( "ssl mode" );
         $port = $ENV{MQPORT} || 5673;
     }


### PR DESCRIPTION
This is useful for users that a. can't reach the normal test server at
rabbitmq.thisaintnews.com and b. do not have SSL enabled on their own
MQHOST.

See GH #94.