### PR TITLE
Declare queue in synopsis

### DIFF
--- a/RabbitMQ.pm
+++ b/RabbitMQ.pm
@@ -20,6 +20,7 @@ Net::AMQP::RabbitMQ - interact with RabbitMQ over AMQP using librabbitmq
   my $mq = Net::AMQP::RabbitMQ->new();
   $mq->connect("localhost", { user => "guest", password => "guest" });
   $mq->channel_open(1);
+  $mq->queue_declare(1, "queuename");
   $mq->publish(1, "queuename", "Hi there!");
   my $gotten = $mq->get(1, "queuename");
   print $gotten->{body} . "\n";


### PR DESCRIPTION
The code in the synopsis does not seem to work. I think we need to declare the queue before we publish to it.