### PR TITLE
Update rabbitmq-c dependencie

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for perl module Net::AMQP::RabbitMQ
 
+2.30001 - 2016-10-18
+    - Bumped rabbitmq-c dependencie
+
 2.30000 - 2016-10-18
     - Fixed segfault on cancel fail
     - Fixed build issue on OSX

--- a/RabbitMQ.pm
+++ b/RabbitMQ.pm
@@ -2,7 +2,7 @@ package Net::AMQP::RabbitMQ;
 use strict;
 use warnings;
 
-our $VERSION = '2.30000';
+our $VERSION = '2.30001';
 
 use XSLoader;
 XSLoader::load "Net::AMQP::RabbitMQ", $VERSION;

--- a/amqp-openssl_bio.c
+++ b/amqp-openssl_bio.c
@@ -1,0 +1,1 @@
+rabbitmq-c/librabbitmq/amqp_openssl_bio.c

--- a/amqp_openssl_hostname_validation.c
+++ b/amqp_openssl_hostname_validation.c
@@ -1,0 +1,1 @@
+rabbitmq-c/librabbitmq/amqp_openssl_hostname_validation.c

--- a/rabbitmq-include/amqp_openssl_bio.h
+++ b/rabbitmq-include/amqp_openssl_bio.h
@@ -1,0 +1,1 @@
+../rabbitmq-c/librabbitmq/amqp_openssl_bio.h

--- a/rabbitmq-include/amqp_openssl_hostname_validation.h
+++ b/rabbitmq-include/amqp_openssl_hostname_validation.h
@@ -1,0 +1,1 @@
+../rabbitmq-c/librabbitmq/amqp_openssl_hostname_validation.h


### PR DESCRIPTION
After bumping rabbitmq-c dependencie and adding new symlinks for missing files, all the tests ran according to the documentation passes.

This fixes #152  