### PR TITLE
DESTROY: Only close connection from opener PID - fixes #151

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -84,10 +84,9 @@ my %WriteMakefileArgs = (
     LIBS            => join( ' ', @libs ),
     INC             => join( ' ', @inc ),
     PREREQ_PM       => {
-        'Math::Int64'           => '0.34',
-        'Scalar::Util'          => '0',
-        'XSLoader'              => '0',
-        'Hash::Util::FieldHash' => '0',
+        'Math::Int64'      => '0.34',
+        'Scalar::Util'     => '0',
+        'XSLoader'         => '0',
     },
     TEST_REQUIRES   => {
         'Sys::Hostname'    => '0',

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -84,9 +84,10 @@ my %WriteMakefileArgs = (
     LIBS            => join( ' ', @libs ),
     INC             => join( ' ', @inc ),
     PREREQ_PM       => {
-        'Math::Int64'      => '0.34',
-        'Scalar::Util'     => '0',
-        'XSLoader'         => '0',
+        'Math::Int64'           => '0.34',
+        'Scalar::Util'          => '0',
+        'XSLoader'              => '0',
+        'Hash::Util::FieldHash' => '0',
     },
     TEST_REQUIRES   => {
         'Sys::Hostname'    => '0',

--- a/RabbitMQ.xs
+++ b/RabbitMQ.xs
@@ -1867,7 +1867,7 @@ net_amqp_rabbitmq_disconnect(conn)
     }
 
 Net::AMQP::RabbitMQ
-net_amqp_rabbitmq_new(clazz)
+net_amqp_rabbitmq__new(clazz)
   char *clazz
   CODE:
     RETVAL = amqp_new_connection();
@@ -1875,12 +1875,17 @@ net_amqp_rabbitmq_new(clazz)
     RETVAL
 
 void
-net_amqp_rabbitmq_DESTROY(conn)
+net_amqp_rabbitmq__destroy_connection_close(conn)
   Net::AMQP::RabbitMQ conn
   CODE:
     if ( amqp_get_socket(conn) != NULL ) {
         amqp_connection_close(conn, AMQP_REPLY_SUCCESS);
     }
+
+void
+net_amqp_rabbitmq__destroy_cleanup(conn)
+  Net::AMQP::RabbitMQ conn
+  CODE:
     empty_amqp_pool( &temp_memory_pool );
     amqp_destroy_connection(conn);
 

--- a/t/033_fork.t
+++ b/t/033_fork.t
@@ -1,6 +1,21 @@
-use Test::More tests => 3;
+use Test::More;
 use strict;
 use warnings;
+
+my $have_fieldhash = eval {
+    require Hash::FieldHash;
+    Hash::FieldHash->import('fieldhash');
+    1;
+} || eval {
+    require Hash::Util;
+    Hash::Util->import('fieldhash');
+    1;
+};
+
+plan skip_all => "Couldn't find a class implementing 'fieldhash'"
+    unless $have_fieldhash;
+
+plan tests => 3;
 
 # When we fork below, if the child closes the parent's connection the parent
 # will sit around for 30 seconds before declaring an error.

--- a/t/033_fork.t
+++ b/t/033_fork.t
@@ -1,0 +1,36 @@
+use Test::More tests => 3;
+use strict;
+use warnings;
+
+# When we fork below, if the child closes the parent's connection the parent
+# will sit around for 30 seconds before declaring an error.
+# This tests:
+# REQUEST: optionally leave connection alive in net_amqp_rabbitmq_DESTROY to
+# allow forking · Issue #151
+# https://github.com/net-amqp-rabbitmq/net-amqp-rabbitmq/issues/151
+
+use FindBin qw/$Bin/;
+use lib "$Bin/lib";
+use NAR::Helper;
+
+my $helper = NAR::Helper->new;
+
+ok $helper->connect, "connected";
+ok $helper->channel_open, "channel_open";
+
+my $max_run_seconds = 10;
+
+my $pid = fork;
+die "fork failed"
+    unless defined $pid;
+
+# just exit from the child - test that this doesn't close the connection that
+# the parent opened.
+exit
+    unless $pid;
+
+# Make sure the child has had a chance to exit (and close the connection if
+# #151 is still valid) before continuing
+waitpid($pid, 0);
+
+ok $helper->exchange_declare, "default exchange declare";


### PR DESCRIPTION
This fixes: REQUEST: optionally leave connection alive in
net_amqp_rabbitmq_DESTROY to allow forking #151

The problem was with forks. If an AMQP connection is open when the fork
occurs both the parent and the child process would close the
connection in DESTROY. It should only be closed by the same process
that opened it.

$self is really a amqp_connection_state_t defined in
rabbitmq-include/amqp.h - one of RabbitMQ's header files. So there is
nowhere to store the creator's PID.

To remedy that, new and DESTROY have been turned into perl subs, that
call their renamed XS counterparts. new() stores the PID in a
fieldhash using Hash::Util::FieldHash inside-out object (see perlobj)
after calling _new(), and DESTROY checks to see whether to close the
connection by comparing the current PID with the PID that created the
connection in new().

Added Hash::Util::FieldHash as a dependency - in core since v5.9.4