### PR TITLE
Support compiling SSL enabled when openssl provided by macports

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -31,10 +31,13 @@ my @inc = ('-I.', '-Irabbitmq-include');
 
 my %checklib_extra_options;
 if ( $^O eq 'darwin') {
-    my $osx_homebrew_openssl_path = "/usr/local/opt/openssl";
+    my $osx_openssl_path = -d "/usr/local/opt/openssl"
+      ? "/usr/local/opt/openssl"
+      : -d "/opt/local"
+        ? "/opt/local" : "/usr/local";
 
-    my $libpath = "${osx_homebrew_openssl_path}/lib";
-    my $incpath = "${osx_homebrew_openssl_path}/include";
+    my $libpath = "${osx_openssl_path}/lib";
+    my $incpath = "${osx_openssl_path}/include";
 
     push @libs, "-L$libpath";
     push @inc, "-I$incpath";


### PR DESCRIPTION
This ensures that it is possible to compile so that `Net::AMQP::RabbitMQ::has_ssl` is true when openssl is installed via macports.

* #178