### PR TITLE
Fix for Issue #142: Problem with Binary data · 

### DIFF
--- a/RabbitMQ.pm
+++ b/RabbitMQ.pm
@@ -313,6 +313,22 @@ C<$props> is an optional hash (the AMQP 'props') respecting the following keys:
        headers => $headers # This should be a hashref of keys and values.
      }
 
+=head3 Publishing Binary Data
+
+By default, C<Net::AMQP::RabbitMQ> makes sure sending and receiving UTF-8
+strings works. That causes problems for binary data like e.g. the output of
+L<JSON>'s C<encode_json()> or L<YAML::XS>'s C<Dump()> because
+C<Net::AMQP::RabbitMQ>'s receiver by default decodes the message body as UTF-8.
+
+To work around that, setup C<< content_encoding => 'binary' >> in C<$props>,
+disabling the UTF_8 decoding. (Any value C<!~ /^UTF-8$/i> will work, but
+C<binary> is suggested by RFC-2045.)
+
+Or you might be able on the receiving side to:
+
+    my $message = $mq->recv();
+    my $binary_data = Encode::decode_utf8($message->{body});
+
 =head2 consume($channel, $queuename, $options)
 
 Put the channel into consume mode.

--- a/t/002_publish_consume.t
+++ b/t/002_publish_consume.t
@@ -20,7 +20,7 @@ ok $helper->drain, "drain queue";
 
 my $props = {
         content_type     => 'text/plain',
-        content_encoding => 'none',
+        content_encoding => 'binary',
         correlation_id   => '123',
         reply_to         => 'somequeue',
         expiration       => 60,

--- a/t/007_get.t
+++ b/t/007_get.t
@@ -67,7 +67,7 @@ ok $helper->channel_open, "channel_open";
 {
     my $props = {
         content_type     => 'text/plain',
-        content_encoding => 'none',
+        content_encoding => 'binary',
         correlation_id   => '123',
         reply_to         => 'somequeue',
         expiration       => 1000,

--- a/t/019_utf8_safety.t
+++ b/t/019_utf8_safety.t
@@ -9,10 +9,7 @@ use NAR::Helper;
 
 my $helper = NAR::Helper->new;
 
-my $dtag1=1;
-my $dtag2=2;
-my $dtag3=3;
-my $dtag4=4;
+my $delivery_tag = 1;
 
 my $options = {
     passive     => 0,
@@ -56,7 +53,7 @@ subtest "Initialization", sub {
             body         => $utf8_payload,
             channel      => 1,
             routing_key  => $helper->{routekey},
-            delivery_tag => $dtag1,
+            delivery_tag => $delivery_tag++,
             redelivered  => 0,
             exchange     => $helper->{exchange},
             consumer_tag => 'ctag',
@@ -84,7 +81,7 @@ subtest "Initialization", sub {
             body         => $ascii_payload,
             channel      => 1,
             routing_key  => $helper->{routekey},
-            delivery_tag => $dtag2,
+            delivery_tag => $delivery_tag++,
             redelivered  => 0,
             exchange     => $helper->{exchange},
             consumer_tag => 'ctag',
@@ -111,7 +108,7 @@ subtest "Headers in UTF-8", sub {
             body         => $ascii_payload,
             channel      => 1,
             routing_key  => $helper->{routekey},
-            delivery_tag => $dtag3,
+            delivery_tag => $delivery_tag++,
             redelivered  => 0,
             exchange     => $helper->{exchange},
             consumer_tag => 'ctag',
@@ -140,7 +137,7 @@ subtest "force utf8 in header strings", sub {
             body         => $ascii_payload,
             channel      => 1,
             routing_key  => $helper->{routekey},
-            delivery_tag => $dtag4,
+            delivery_tag => $delivery_tag++,
             redelivered  => 0,
             exchange     => $helper->{exchange},
             consumer_tag => 'ctag',

--- a/t/019_utf8_safety.t
+++ b/t/019_utf8_safety.t
@@ -69,7 +69,7 @@ ok $helper->consume( $queuename ), "consume";
 my $ascii_payload = "Some ASCII payload";
 
 {
-    ok $helper->publish( $ascii_payload, { content_encoding => 'C' } ), "publish";
+    ok $helper->publish( $ascii_payload, { content_encoding => 'binary' } ), "publish";
 
     my $rv = $helper->recv;
     ok $rv, "recv";
@@ -84,14 +84,14 @@ my $ascii_payload = "Some ASCII payload";
             redelivered  => 0,
             exchange     => $helper->{exchange},
             consumer_tag => 'ctag',
-            props        => { 'content_encoding' => 'C' },
+            props        => { 'content_encoding' => 'binary' },
         },
         "payload"
     );
     ok !utf8::is_utf8( $rv->{'body'} ), 'not utf8';
 }
 
-my $pub_props = { content_encoding => 'C', headers => { "sample" => "sample" } };
+my $pub_props = { content_encoding => 'binary', headers => { "sample" => "sample" } };
 {
 # Now, don't go out of your way to set the headers to UTF-8, they should still
 # come back as that.

--- a/t/021_json_utf8_in_and_out.t
+++ b/t/021_json_utf8_in_and_out.t
@@ -2,19 +2,26 @@ use strict;
 use warnings;
 use Test::More;
 use utf8;
+use Encode;
 
 my $has_json = eval("use JSON; 1");
 if ( $@ ) {
      plan skip_all => "Missing JSON.pm";
 } else {
-     plan tests => 3;
+     plan tests => 6;
 }
 
 use FindBin qw/$Bin/;
 use lib "$Bin/lib";
 use NAR::Helper;
 
-# About JSON's to_json:
+# About the difference between JSON's encode_json and to_json:
+#
+# $json_text = encode_json $perl_scalar
+#     is equivalent to:
+# $json_text = JSON->new->utf8->encode($perl_scalar)
+#
+# It returns a binary string (without the UTF-8 flag set).
 #
 # $json_text = to_json($perl_scalar)
 #     is equivalent to:
@@ -22,8 +29,16 @@ use NAR::Helper;
 #
 # It returns a UTF-8 encoded string (with the UTF-8 flag set).
 #
-# And for completeness, from_json is the opposite of to_json. So they go as a
-# pair: (to_json, from_json).
+# So:
+#
+# encode_json($perl_scalar) eq Encode::encode_utf8(to_json($perl_scalar))
+#
+# The JSON documentation prefers encode_json over to_json throughout (except to
+# document to_json itself)
+#
+# And for completeness, decode_json is the opposite of encode_json and
+# from_json is the opposite of to_json. So they come as pairs: (encode_json,
+# decode_json) and (to_json, from_json).
 
 my $helper = NAR::Helper->new;
 
@@ -39,6 +54,67 @@ subtest "initialization", sub {
 };
 
 my $delivery_tag = 1;
+
+# here we test JSON using UTF-8 characters (not octets) using encode_json/decode_json
+my $utf8_payload_octets = encode_json({"message" => "Mǎgìc Trañsiént Paylöàd"});
+ok ! utf8::is_utf8($utf8_payload_octets), 'message going in is not utf8';
+
+subtest "UTF-8 binary string works with content_encoding: binary", sub {
+    ok $helper->publish( $utf8_payload_octets, { content_encoding => 'binary' } ), "publish";
+
+    my $rv = $helper->recv;
+    ok $rv, "recv";
+
+    is_deeply(
+        $rv,
+        {
+            body         => $utf8_payload_octets,
+            channel      => 1,
+            routing_key  => $helper->{routekey},
+            delivery_tag => $delivery_tag++,
+            redelivered  => 0,
+            exchange     => $helper->{exchange},
+            consumer_tag => 'ctag',
+            props        => { 'content_encoding' => 'binary' },
+        },
+        "payload"
+    );
+
+    ok ! utf8::is_utf8($rv->{'body'}), 'verify body back is not utf8 flagged';
+
+    ok decode_json( $rv->{body} ), "rv body is valid json";
+};
+
+subtest "UTF-8 binary string doesn't work without content_encoding (need to manualy decode_utf8)", sub {
+    # Note how this test doesn't give you back the data that got published...
+    ok $helper->publish( $utf8_payload_octets ), "publish";
+
+    my $rv = $helper->recv;
+    ok $rv, "recv";
+
+    is_deeply(
+        $rv,
+        {
+            # Notice how we have to decode here to get at the original octets
+            # (it does decode properly, though)
+            body         => Encode::decode('UTF-8', $utf8_payload_octets, Encode::FB_CROAK),
+            channel      => 1,
+            routing_key  => $helper->{routekey},
+            delivery_tag => $delivery_tag++,
+            redelivered  => 0,
+            exchange     => $helper->{exchange},
+            consumer_tag => 'ctag',
+            props        => {},
+        },
+        "payload"
+    );
+
+    ok utf8::is_utf8($rv->{'body'}), 'verify body back is utf8 flagged';
+
+    # Note that this is from_json, not decode_json. The lack of
+    # content_encoding => 'binary' causes it to be decoded as UTF-8.
+    ok from_json( $rv->{body} ), "rv body is valid, UTF-8 encoded json";
+};
 
 # here we test JSON using UTF-8 characters (not octets) using to_json/from_json
 subtest "UTF-8 encoded string - without content_encoding", sub {

--- a/t/021_json_utf8_in_and_out.t
+++ b/t/021_json_utf8_in_and_out.t
@@ -62,7 +62,7 @@ ok from_json( $utf8_payload ), "utf8_payload is valid json";
 
 my $ascii_payload = "Some ASCII payload";
 {
-    ok $helper->publish( $ascii_payload, { content_encoding => 'C' } ), "publish";
+    ok $helper->publish( $ascii_payload, { content_encoding => 'binary' } ), "publish";
 
     my $rv = $helper->recv;
     ok $rv, "recv";
@@ -77,7 +77,7 @@ my $ascii_payload = "Some ASCII payload";
             redelivered  => 0,
             exchange     => $helper->{exchange},
             consumer_tag => 'ctag',
-            props        => { 'content_encoding' => 'C' },
+            props        => { 'content_encoding' => 'binary' },
         },
         "payload"
     );

--- a/t/021_json_utf8_in_and_out.t
+++ b/t/021_json_utf8_in_and_out.t
@@ -14,6 +14,17 @@ use FindBin qw/$Bin/;
 use lib "$Bin/lib";
 use NAR::Helper;
 
+# About JSON's to_json:
+#
+# $json_text = to_json($perl_scalar)
+#     is equivalent to:
+# $json_text = JSON->new->encode($perl_scalar)
+#
+# It returns a UTF-8 encoded string (with the UTF-8 flag set).
+#
+# And for completeness, from_json is the opposite of to_json. So they go as a
+# pair: (to_json, from_json).
+
 my $helper = NAR::Helper->new;
 
 ok $helper->connect, "connected";
@@ -25,7 +36,10 @@ ok $helper->drain, "drain queue";
 
 ok $helper->consume, "consume";
 
-my $utf8_payload = '{"message":"Mǎgìc Trañsiént Paylöàd"}';
+my $delivery_tag = 1;
+
+# here we test JSON using UTF-8 characters (not octets) using to_json/from_json
+my $utf8_payload = to_json({"message" => "Mǎgìc Trañsiént Paylöàd"});
 ok utf8::is_utf8($utf8_payload), 'message going in is utf8';
 my $utf8_headers = {
     dummy => 'Sóme ŭtf8 strìng'
@@ -45,7 +59,7 @@ ok from_json( $utf8_payload ), "utf8_payload is valid json";
             body         => $utf8_payload,
             channel      => 1,
             routing_key  => $helper->{routekey},
-            delivery_tag => 1,
+            delivery_tag => $delivery_tag++,
             redelivered  => 0,
             exchange     => $helper->{exchange},
             consumer_tag => 'ctag',
@@ -73,7 +87,7 @@ my $ascii_payload = "Some ASCII payload";
             body         => $ascii_payload,
             channel      => 1,
             routing_key  => $helper->{routekey},
-            delivery_tag => 2,
+            delivery_tag => $delivery_tag++,
             redelivered  => 0,
             exchange     => $helper->{exchange},
             consumer_tag => 'ctag',


### PR DESCRIPTION
* Document why and how to use `content_type => 'binary'` for binary data in RabbitMQ.pm perldoc
* Test cases
    * Update test cases in t/*.t to use Use `content_type => 'binary'` instead of 'C' to follow RFC-2045
    * Split two t/*.t test cases into subtests for clearer code and output
    * Add testcases using `JSON::encode_json` and [@chamarreddy's sample_pack test case](https://github.com/net-amqp-rabbitmq/net-amqp-rabbitmq/issues/142#issuecomment-259040974)