### PR TITLE
allow setting client_properties in connect

### DIFF
--- a/t/029_amqp_properties.t
+++ b/t/029_amqp_properties.t
@@ -1,4 +1,4 @@
-use Test::More tests => 8;
+use Test::More tests => 7;
 use strict;
 use warnings;
 
@@ -21,4 +21,3 @@ my $client_properties = $helper->get_client_properties;
 ok $client_properties, "get_client_properties";
 ok exists( $client_properties->{product} ), 'product should be returned';
 is $client_properties->{'product'}, 'rabbitmq-c', 'product is rabbitmq-c';
-is $client_properties->{connection_name}, 'nar_test','connection_name is nar_test';

--- a/t/029_amqp_properties.t
+++ b/t/029_amqp_properties.t
@@ -1,4 +1,4 @@
-use Test::More tests => 7;
+use Test::More tests => 8;
 use strict;
 use warnings;
 
@@ -21,3 +21,4 @@ my $client_properties = $helper->get_client_properties;
 ok $client_properties, "get_client_properties";
 ok exists( $client_properties->{product} ), 'product should be returned';
 is $client_properties->{'product'}, 'rabbitmq-c', 'product is rabbitmq-c';
+is $client_properties->{connection_name}, 'nar_test','connection_name is nar_test';

--- a/t/034_connect_client_properties.t
+++ b/t/034_connect_client_properties.t
@@ -14,4 +14,5 @@ my $client_properties = {
 };
 
 ok $helper->mq->connect($helper->{host}, $connection_options, $client_properties), 'connected';
-is $client_properties->{connection_name}, 'nar_test','connection_name is nar_test';
+my $test_client_properties = $helper->get_client_properties;
+is $test_client_properties->{connection_name}, $client_properties->{connection_name},'connection_name set';

--- a/t/034_connect_client_properties.t
+++ b/t/034_connect_client_properties.t
@@ -1,0 +1,17 @@
+use Test::More tests => 2;
+use strict;
+use warnings;
+
+use FindBin qw/$Bin/;
+use lib "$Bin/lib";
+use NAR::Helper;
+
+my $helper = NAR::Helper->new;
+
+my $connection_options = $helper->get_connection_options();
+my $client_properties = {
+	connection_name => 'nar_test',
+};
+
+ok $helper->mq->connect($helper->{host}, $connection_options, $client_properties), 'connected';
+is $client_properties->{connection_name}, 'nar_test','connection_name is nar_test';

--- a/t/lib/NAR/Helper.pm
+++ b/t/lib/NAR/Helper.pm
@@ -130,9 +130,6 @@ sub connect {
         ssl_init        => $self->{ssl_init},
         vhost           => $self->{vhost},
     };
-	my $client_properties = {
-		connection_name => 'nar_test',
-	};
     if ( defined $heartbeat ) {
         $options->{heartbeat} = $heartbeat;
     }
@@ -141,8 +138,25 @@ sub connect {
     }
 
     $self->_ok( sub {
-        $self->mq->connect( $self->{host}, $options, $client_properties );
+        $self->mq->connect( $self->{host}, $options );
     } );
+}
+
+sub get_connection_options {
+    my ( $self ) = @_;
+
+    return {
+        user            => $self->{username},
+        password        => $self->{password},
+        port            => $self->{port},
+        ssl             => $self->{ssl},
+        ssl_verify_host => $self->{ssl_verify_host},
+        ssl_verify_peer => $self->{ssl_verify_peer},
+        ssl_cacert      => $self->{ssl_cacert},
+        ssl_init        => $self->{ssl_init},
+        vhost           => $self->{vhost},
+    };
+
 }
 
 sub heartbeat {

--- a/t/lib/NAR/Helper.pm
+++ b/t/lib/NAR/Helper.pm
@@ -130,6 +130,9 @@ sub connect {
         ssl_init        => $self->{ssl_init},
         vhost           => $self->{vhost},
     };
+	my $client_properties = {
+		connection_name => 'nar_test',
+	};
     if ( defined $heartbeat ) {
         $options->{heartbeat} = $heartbeat;
     }
@@ -138,7 +141,7 @@ sub connect {
     }
 
     $self->_ok( sub {
-        $self->mq->connect( $self->{host}, $options );
+        $self->mq->connect( $self->{host}, $options, $client_properties );
     } );
 }
 


### PR DESCRIPTION
This allows setting connection_name (and potentially other settings) on the connection helping in debugging and troubleshooting.
This changes the amqp_login to amqp_login_with_properties that already existed.