### PR TITLE
fix: docs publisher_confirm_wait timeout from seconds to milliseconds

### DIFF
--- a/RabbitMQ.pm
+++ b/RabbitMQ.pm
@@ -577,7 +577,7 @@ Note that there is presently no way to disable select mode on a channel, so in o
 
 Wait for a publisher confirm from the broker. If no publisher confirm has appeared before the timeout expires, C<undef> is returned.
 
-C<$timeout> is an C<integer> representing the amount of time, in seconds, to wait for a confirmation. If a positive timeout is not specified or is specified as zero, this call will block until a response is received. If you specify a negative value for the timeout, it will time out immediately.
+C<$timeout> is an C<integer> representing the amount of time, in milliseconds, to wait for a confirmation. If a positive timeout is not specified or is specified as zero, this call will block until a response is received. If you specify a negative value for the timeout, it will time out immediately.
 
 When a response is received, a hashref will be returned in the appropriate format for the method returned.
 

--- a/t/lib/NAR/Helper.pm
+++ b/t/lib/NAR/Helper.pm
@@ -653,7 +653,7 @@ sub confirm_select {
 sub publisher_confirm_wait {
   my ( $self, $timeout_sec ) = @_;
 
-  # Default to 2 seconds of wait
+  # Default to 2 milliseconds of wait
   $timeout_sec ||= 2;
 
   my $rv;


### PR DESCRIPTION
Fix for:

https://github.com/net-amqp-rabbitmq/net-amqp-rabbitmq/issues/257

Code expects ms not s:

https://github.com/net-amqp-rabbitmq/net-amqp-rabbitmq/blob/568811e6268a41df867d0e9e96ac2c0fcd4b8acc/RabbitMQ.xs#L2044